### PR TITLE
Update search functionality

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -100,7 +100,7 @@ const searchHandler = function (e) {
   }
 };
 
-searchInput.addEventListener('keypress', searchHandler);
+searchInput.addEventListener('keyup', searchHandler);
 
 function addCredentialsToList(credentials, credentialName, list) {
   const item = document.createElement('li');


### PR DESCRIPTION
Update the search functionality with the following:

1. Modified the event listener so that it only starts running when Enter is pressed. This prevents the aggressive reload every time the searchString changes.
2. Moved the "No matching key" messages out of the for loop, so they don't get sent every time a secret is iterated on. Instead, a message will be sent at the end of the search.
3. Split the "No matching key" messages, so they better indicate whether it was a search or "default page load behaviour" that yielded no results.
4. Modified search behaviour so that it can search for substrings. Ie if the secret is "bbc.com", and we search for "bbc.co", it will be found as a match during manual search.
5. After the search string is set to empty and Enter is pressed, the default behaviour will take place