### PR TITLE
Allow custom secrets path and multiple passwords for the same website

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,7 +3,7 @@ env:
   es6: true
 extends: 'eslint:recommended'
 parserOptions:
-  ecmaVersion: 2019
+  ecmaVersion: 2020
 rules:
   indent:
     - error

--- a/README.md
+++ b/README.md
@@ -21,17 +21,48 @@ The token grabber feature allows this plugin to effectively use any Vault authen
 
 ## Requirements
 
-Vault needs to be prepared to use this extention.
-This extention expects secrets to be saved in the 'secret' mount path (the default KV store).
-Version 1 and 2 of the KV store are supported - only difference are the Vault policies you will have to write.
-The path in this mount should be `/vaultPass/[someOrg]/url` where:
+1. Vault needs to be prepared to use this extension.
+Usernames and passwords we wish to retrieve from Vault need to be defined in a KV store.
+Version 1 and 2 of the KV store are supported - only differences are the Vault policies you will have to write.
 
-- `someOrg` will be some organisational level in your company to separate access levels
-  - You can activate and deactivate these "folders" in options
-- `url` is a URL or part of it that the credentials should match for
-  - Be aware that \* characters (and potentially others...) may not work!
-  - It should have _at least_ the keys `username` and `password` with the respective information
-- Get a Token via the options page of this extention
+2. By default, secrets should be created using the following path template:
+ `/secret/vaultPass/[someOrg]/[url]` where:
+
+   - `someOrg` will be some organisational level in your company to separate access levels
+     - You can activate and deactivate these "folders" in options
+   - `url` is a RegEx used to match the website's URL that the credentials are for
+     - Be aware that \*, ?, ., \\, ^, $ (and potentially others...) have a special meaning when in a regular expression hence might not trigger the behaviour that you might expect. Check your regular expression using an online tools like regex101.com if in doubt.
+
+  Examples: 
+  `/secret/vaultPass/marketing/github.com` to define credentials for any URLs that contains `github.com`
+  `/secret/vaultPass/accounting/api.*.github.com(.au){0,1}` to define credentials for any URLs that contains `api` followed by anything then ends with `github.com` or `gitlab.com.au`
+     
+3. Each secret should have _at least_ one `username` key and one `password` key with the respective information.
+
+Example:
+```
+{
+  "username": "john.smith@internet.com",
+  "password": "mySecretPassword"
+}
+```
+4. However, if you have more than one valid set of credentials for the same website, you can define multiple pairs of username/password combinations. Just add them with an additional suffix ensuring that each username has a corresponding password.
+
+ Example:
+```
+{
+  "username": "myusername",
+  "password": "mypassword",
+  "username.2": "other username",
+  "password.2": "other password",
+  "username for test": "test username",
+  "password for test": "test password"
+}
+```
+5. Get a Token via the options page of this extension
+
+**_NOTE:_** You can now store your credentials in any KV store within your Vault instance, not just `/secret/vaultPass`
+Just specify your custom secrets' path in the Options page of the extension.
 
 ## Example policies
 
@@ -40,7 +71,7 @@ There are two short docs to get your started with access policies:
 - [KV version 1](docs/access_policies_v1.md)
 - [KV version 2](docs/access_policies_v2.md)
 
-If you just installed Vault - you propably have Version 2.
+If you just installed Vault - you probably have Version 2.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -22,33 +22,36 @@ The token grabber feature allows this plugin to effectively use any Vault authen
 ## Requirements
 
 1. Vault needs to be prepared to use this extension.
-Usernames and passwords we wish to retrieve from Vault need to be defined in a KV store.
-Version 1 and 2 of the KV store are supported - only differences are the Vault policies you will have to write.
+   Usernames and passwords we wish to retrieve from Vault need to be defined in a KV store.
+   Version 1 and 2 of the KV store are supported - only differences are the Vault policies you will have to write.
 
 2. By default, secrets should be created using the following path template:
- `/secret/vaultPass/[someOrg]/[url]` where:
+   `/secret/vaultPass/[someOrg]/[url]` where:
 
    - `someOrg` will be some organisational level in your company to separate access levels
      - You can activate and deactivate these "folders" in options
    - `url` is a RegEx used to match the website's URL that the credentials are for
      - Be aware that \*, ?, ., \\, ^, $ (and potentially others...) have a special meaning when in a regular expression hence might not trigger the behaviour that you might expect. Check your regular expression using an online tools like regex101.com if in doubt.
 
-  Examples: 
-  `/secret/vaultPass/marketing/github.com` to define credentials for any URLs that contains `github.com`
-  `/secret/vaultPass/accounting/api.*.github.com(.au){0,1}` to define credentials for any URLs that contains `api` followed by anything then ends with `github.com` or `gitlab.com.au`
-     
+Examples:
+`/secret/vaultPass/marketing/github.com` to define credentials for any URLs that contains `github.com`
+`/secret/vaultPass/accounting/api.*.github.com(.au){0,1}` to define credentials for any URLs that contains `api` followed by anything then ends with `github.com` or `gitlab.com.au`
+
 3. Each secret should have _at least_ one `username` key and one `password` key with the respective information.
 
 Example:
+
 ```
 {
   "username": "john.smith@internet.com",
   "password": "mySecretPassword"
 }
 ```
+
 4. However, if you have more than one valid set of credentials for the same website, you can define multiple pairs of username/password combinations. Just add them with an additional suffix ensuring that each username has a corresponding password.
 
- Example:
+Example:
+
 ```
 {
   "username": "myusername",
@@ -59,6 +62,7 @@ Example:
   "password for test": "test password"
 }
 ```
+
 5. Get a Token via the options page of this extension
 
 **_NOTE:_** You can now store your credentials in any KV store within your Vault instance, not just `/secret/vaultPass`
@@ -145,7 +149,7 @@ Success! Data written to: auth/ldap/groups/admin_staff
 ```
 
 Afterwards you can login to this Vault instance with the VaultPass extension like this:
-![VaultPass dev login](docs/VaultPassDevLogin.png "VaultPass dev login")
+![VaultPass dev login](docs/VaultPassDevLogin.png 'VaultPass dev login')
 
 Use `foo` as the password for the `mitchellh` user.
 
@@ -177,7 +181,7 @@ token_meta_username    hermes
 As you can see, we logged in as "hermes" who is member of the "admin_staff" group and we get the default and admin policy applied. If we try the same as fry, we only get the default policy applied:
 
 ```bash
-$ docker exec -it --env 'VAULT_ADDR=http://127.0.0.1:8200' dev-vault sh -c 'vault login -method=ldap username=fry'  
+$ docker exec -it --env 'VAULT_ADDR=http://127.0.0.1:8200' dev-vault sh -c 'vault login -method=ldap username=fry'
 Password (will be hidden):
 Success! You are now authenticated. The token information displayed below
 is already stored in the token helper. You do NOT need to run "vault login"

--- a/background.js
+++ b/background.js
@@ -102,7 +102,7 @@ async function autoFillSecrets(message, sender) {
   if (loginCount == 0) {
     return;
   }
-  chrome.action.setBadgeText({ text: `${loginCount}`, tabId: sender.tab.id });
+  chrome.action.setBadgeText({ text: `*`, tabId: sender.tab.id });
 }
 
 chrome.runtime.onMessage.addListener(function (message, sender) {

--- a/background.js
+++ b/background.js
@@ -94,11 +94,11 @@ async function autoFillSecrets(message, sender) {
 
   let loginCount = 0;
 
-  for (let secret of secretList) {
+  for (const secret of secretList) {
     const secretKeys = await vault.list(`/${storeComponents.root}/metadata/${storeComponents.subPath}/${secret}`);
-    for (let key of secretKeys.data.keys) {
-      var pattern = new RegExp(key);
-      var patternMatches = pattern.test(hostname);
+    for (const key of secretKeys.data.keys) {
+      const pattern = new RegExp(key);
+      const patternMatches = pattern.test(hostname);
       // If the key is an exact match to the current hostname --> autofill
       if (hostname === clearHostname(key)) {
         const credentials = await vault.get(

--- a/background.js
+++ b/background.js
@@ -69,7 +69,7 @@ function storePathComponents(storePath) {
   return {
     root: storeRoot,
     subPath: storeSubPath
-  }
+  };
 }
 
 function clearHostname(hostname) {
@@ -117,7 +117,7 @@ async function autoFillSecrets(message, sender) {
     }
   }
   if (loginCount > 0) {
-    chrome.action.setBadgeText({ text: `*`, tabId: sender.tab.id });
+    chrome.action.setBadgeText({ text: '*', tabId: sender.tab.id });
   }
 }
 

--- a/common.js
+++ b/common.js
@@ -1,17 +1,19 @@
 /* eslint-disable no-console */
+/* eslint-disable no-unused-vars */
 /* global browser */
 
 function storePathComponents(storePath) {
-    let path = 'secret/vaultPass';
-    if (storePath && storePath.length > 0) {
-        path = storePath;
-    }
-    const pathComponents = path.split('/');
-    const storeRoot = pathComponents[0];
-    const storeSubPath = pathComponents.length > 0 ? pathComponents.slice(1).join('/') : '';
+  let path = 'secret/vaultPass';
+  if (storePath && storePath.length > 0) {
+    path = storePath;
+  }
+  const pathComponents = path.split('/');
+  const storeRoot = pathComponents[0];
+  const storeSubPath =
+    pathComponents.length > 0 ? pathComponents.slice(1).join('/') : '';
 
-    return {
-        root: storeRoot,
-        subPath: storeSubPath
-    }
+  return {
+    root: storeRoot,
+    subPath: storeSubPath,
+  };
 }

--- a/common.js
+++ b/common.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+/* global browser */
+
+function storePathComponents(storePath) {
+    let path = 'secret/vaultPass';
+    if (storePath && storePath.length > 0) {
+        path = storePath;
+    }
+    const pathComponents = path.split('/');
+    const storeRoot = pathComponents[0];
+    const storeSubPath = pathComponents.length > 0 ? pathComponents.slice(1).join('/') : '';
+
+    return {
+        root: storeRoot,
+        subPath: storeSubPath
+    }
+}

--- a/content.js
+++ b/content.js
@@ -38,7 +38,11 @@ function handleCopyToClipboard(request) {
   }
 }
 
-function findUsernameNodeIn(parentNode, checkVisibility, isUserTriggered = false) {
+function findUsernameNodeIn(
+  parentNode,
+  checkVisibility,
+  isUserTriggered = false
+) {
   const matches = [
     '[autocomplete="email"]',
     '[autocomplete="username"]',
@@ -63,7 +67,7 @@ function findUsernameNodeIn(parentNode, checkVisibility, isUserTriggered = false
   if (parentNode instanceof HTMLFormElement || isUserTriggered) {
     matches.push('[type="text"]');
   }
-  
+
   for (const selector of matches) {
     const allUsernameNodes = parentNode.querySelectorAll(selector);
 
@@ -77,9 +81,9 @@ function findUsernameNodeIn(parentNode, checkVisibility, isUserTriggered = false
     if (usernameNode) {
       return usernameNode;
     }
-   }
+  }
 
-   return null;
+  return null;
 }
 
 function createEvent(name) {
@@ -133,9 +137,9 @@ function handleFetchToken() {
       continue;
     }
     if (
-      Object.prototype.hasOwnProperty.call(element,'token') &&
-      Object.prototype.hasOwnProperty.call(element,'ttl') &&
-      Object.prototype.hasOwnProperty.call(element,'policies')
+      Object.prototype.hasOwnProperty.call(element, 'token') &&
+      Object.prototype.hasOwnProperty.call(element, 'ttl') &&
+      Object.prototype.hasOwnProperty.call(element, 'policies')
     ) {
       browser.runtime.sendMessage({
         type: 'fetch_token',

--- a/content.js
+++ b/content.js
@@ -61,11 +61,11 @@ function findUsernameNodeIn(parentNode, checkVisibility) {
     '[type="text"]',
   ];
 
-  for (let selector of matches) {
+  for (const selector of matches) {
     const allUsernameNodes = parentNode.querySelectorAll(selector);
 
     let usernameNode = null;
-    for (let node of allUsernameNodes) {
+    for (const node of allUsernameNodes) {
       if (checkVisibility ? node.offsetParent : true) {
         usernameNode = node;
         break;
@@ -96,7 +96,7 @@ function fillIn(node, value) {
 function findPasswordInput() {
   // eslint-disable-next-line quotes
   const passwordNodes = document.querySelectorAll("input[type='password']");
-  for (let node of passwordNodes) {
+  for (const node of passwordNodes) {
     if (node.offsetParent) return node;
   }
 

--- a/content.js
+++ b/content.js
@@ -62,13 +62,11 @@ function findUsernameNodeIn(parentNode, checkVisibility) {
   ];
 
   for (let selector of matches) {
-    console.log(selector);
     const allUsernameNodes = parentNode.querySelectorAll(selector);
 
     let usernameNode = null;
     for (let node of allUsernameNodes) {
       if (checkVisibility ? node.offsetParent : true) {
-        console.log(node);
         usernameNode = node;
         break;
       }
@@ -109,7 +107,6 @@ function handleFillCredits(request) {
   const passwordNode = findPasswordInput();
   // A number of websites now prompt for the password separately
   if (passwordNode) {
-    console.log(passwordNode);
     fillIn(passwordNode, request.password);
   }
 

--- a/content.js
+++ b/content.js
@@ -62,11 +62,13 @@ function findUsernameNodeIn(parentNode, checkVisibility) {
   ];
 
   for (let selector of matches) {
+    console.log(selector);
     const allUsernameNodes = parentNode.querySelectorAll(selector);
 
     let usernameNode = null;
     for (let node of allUsernameNodes) {
       if (checkVisibility ? node.offsetParent : true) {
+        console.log(node);
         usernameNode = node;
         break;
       }
@@ -107,6 +109,7 @@ function handleFillCredits(request) {
   const passwordNode = findPasswordInput();
   // A number of websites now prompt for the password separately
   if (passwordNode) {
+    console.log(passwordNode);
     fillIn(passwordNode, request.password);
   }
 

--- a/content.js
+++ b/content.js
@@ -38,7 +38,7 @@ function handleCopyToClipboard(request) {
   }
 }
 
-function findUsernameNodeIn(parentNode, checkVisibility) {
+function findUsernameNodeIn(parentNode, checkVisibility, isUserTriggered = false) {
   const matches = [
     '[autocomplete="email"]',
     '[autocomplete="username"]',
@@ -58,9 +58,12 @@ function findUsernameNodeIn(parentNode, checkVisibility) {
     '[type="text"][name="mail"]',
     '[type="text"][name="nickname"]',
     '[type="text"][name="nick"]',
-    '[type="text"]',
   ];
 
+  if (parentNode instanceof HTMLFormElement || isUserTriggered) {
+    matches.push('[type="text"]');
+  }
+  
   for (const selector of matches) {
     const allUsernameNodes = parentNode.querySelectorAll(selector);
 
@@ -115,7 +118,7 @@ function handleFillCredits(request) {
   // https://stackoverflow.com/a/21696585
   const usernameNode = formNode
     ? findUsernameNodeIn(formNode)
-    : findUsernameNodeIn(document, true);
+    : findUsernameNodeIn(document, true, request.isUserTriggered);
   if (!usernameNode) return;
 
   fillIn(usernameNode, request.username);

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["browser-polyfill.min.js", "content.js"]
+      "js": ["browser-polyfill.min.js", "content.js", "common.js"]
     }
   ],
   "background": {

--- a/manifestV2.json
+++ b/manifestV2.json
@@ -16,7 +16,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["browser-polyfill.min.js", "content.js"]
+      "js": ["browser-polyfill.min.js", "content.js", "common.js"]
     }
   ],
   "background": {

--- a/manifestV3.json
+++ b/manifestV3.json
@@ -18,7 +18,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["browser-polyfill.min.js", "content.js"]
+      "js": ["browser-polyfill.min.js", "content.js", "common.js"]
     }
   ],
   "background": {

--- a/options.html
+++ b/options.html
@@ -51,7 +51,7 @@
         </label>
 
         <label class="label">
-          Auth Mountpoint:
+          Auth Method:
           <input
             type="text"
             list="mounts"
@@ -65,6 +65,11 @@
             <option>radius</option>
             <option>okta</option>
           </datalist>
+        </label>
+
+        <label class="label">
+          KV Store:
+          <input type="text" class="input" name="store" id="storeBox" placeholder="Path to the KV store within Vault" value="secret/vaultPass"/>
         </label>
 
         <input
@@ -91,6 +96,7 @@
     </main>
 
     <script src="Notify.js"></script>
+    <script src="common.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -4,10 +4,10 @@
 const notify = new Notify(document.querySelector('#notify'));
 async function mainLoaded() {
   // get inputs from form elements, server URL, login and password
-  var vaultServer = document.getElementById('serverBox');
-  var login = document.getElementById('loginBox');
-  var auth = document.getElementById('authMount');
-  var store = document.getElementById('storeBox');
+  const vaultServer = document.getElementById('serverBox');
+  const login = document.getElementById('loginBox');
+  const auth = document.getElementById('authMount');
+  const store = document.getElementById('storeBox');
 
   // put listener on login button
   document
@@ -20,28 +20,28 @@ async function mainLoaded() {
     .getElementById('logoutButton')
     .addEventListener('click', logout, false);
 
-  var vaultServerAddress = (await browser.storage.sync.get('vaultAddress'))
+  const vaultServerAddress = (await browser.storage.sync.get('vaultAddress'))
     .vaultAddress;
   if (vaultServerAddress) {
     vaultServer.value = vaultServerAddress;
     vaultServer.parentNode.classList.add('is-dirty');
   }
-  var username = (await browser.storage.sync.get('username')).username;
+  const username = (await browser.storage.sync.get('username')).username;
   if (username) {
     login.value = username;
     login.parentNode.classList.add('is-dirty');
   }
-  var authMethod = (await browser.storage.sync.get('authMethod')).authMethod;
+  const authMethod = (await browser.storage.sync.get('authMethod')).authMethod;
   if (authMethod) {
     auth.value = authMethod;
     auth.parentNode.classList.add('is-dirty');
   }
-  var storePath = (await browser.storage.sync.get('storePath')).storePath;
+  const storePath = (await browser.storage.sync.get('storePath')).storePath;
   if (storePath) {
     store.value = storePath;
     store.parentNode.classList.add('is-dirty');
   }
-  var vaultToken = (await browser.storage.local.get('vaultToken')).vaultToken;
+  const vaultToken = (await browser.storage.local.get('vaultToken')).vaultToken;
   if (vaultToken) {
     try {
       await querySecrets(vaultServerAddress, vaultToken, null, storePath);
@@ -64,7 +64,7 @@ async function querySecrets(vaultServerAddress, vaultToken, policies, storePath)
 
   const storeComponents = storePathComponents(storePath);
 
-  var fetchListOfSecretDirs = await fetch(
+  const fetchListOfSecretDirs = await fetch(
     `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}`,
     {
       method: 'LIST',
@@ -102,7 +102,7 @@ async function logout() {
 }
 
 async function displaySecrets(secrets, activeSecrets) {
-  var list = document.getElementById('secretList');
+  const list = document.getElementById('secretList');
   
   for (const secret of secrets) {
     // Create the list item:
@@ -139,30 +139,30 @@ async function displaySecrets(secrets, activeSecrets) {
 }
 
 async function secretChanged({ checkbox, item }) {
-  var activeSecrets = (await browser.storage.sync.get('secrets')).secrets;
+  let activeSecrets = (await browser.storage.sync.get('secrets')).secrets;
   if (!activeSecrets) {
     activeSecrets = [];
   }
 
   if (checkbox.checked) {
-    var vaultServerAddress = (await browser.storage.sync.get('vaultAddress'))
-      .vaultAddress;
-    var vaultToken = (await browser.storage.local.get('vaultToken')).vaultToken;
+    const vaultServerAddress = (await browser.storage.sync.get('vaultAddress'))
+        .vaultAddress;
+    const vaultToken = (await browser.storage.local.get('vaultToken')).vaultToken;
     if (!vaultToken) {
       throw new Error('secretChanged: Vault Token is empty after login');
     }
 
-    var storePath = (await browser.storage.sync.get('storePath')).storePath;
+    const storePath = (await browser.storage.sync.get('storePath')).storePath;
     const storeComponents = storePathComponents(storePath);
-    var fetchListOfSecretsForDir = await fetch(
-      `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${checkbox.name}`,
-      {
-        method: 'LIST',
-        headers: {
-          'X-Vault-Token': vaultToken,
-          'Content-Type': 'application/json',
-        },
-      }
+    const fetchListOfSecretsForDir = await fetch(
+        `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${checkbox.name}`,
+        {
+          method: 'LIST',
+          headers: {
+            'X-Vault-Token': vaultToken,
+            'Content-Type': 'application/json',
+          },
+        }
     );
     if (!fetchListOfSecretsForDir.ok) {
       checkbox.checked = false;
@@ -190,15 +190,15 @@ async function secretChanged({ checkbox, item }) {
 
 // invoked after user clicks "login to vault" button, if all fields filled in, and URL passed regexp check.
 async function authToVault(vaultServer, username, password, authMethod, storePath) {
-  var loginToVault = await fetch(
-    `${vaultServer}/v1/auth/${authMethod}/login/${username}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ password: password }),
-    }
+  const loginToVault = await fetch(
+      `${vaultServer}/v1/auth/${authMethod}/login/${username}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({password: password}),
+      }
   );
   if (!loginToVault.ok) {
     notify.error(`
@@ -217,11 +217,11 @@ async function authToVault(vaultServer, username, password, authMethod, storePat
 
 async function authButtonClick() {
   // get inputs from form elements, server URL, login and password
-  var vaultServer = document.getElementById('serverBox');
-  var login = document.getElementById('loginBox');
-  var authMount = document.getElementById('authMount');
-  var pass = document.getElementById('passBox');
-  var storePath = document.getElementById('storeBox');
+  const vaultServer = document.getElementById('serverBox');
+  const login = document.getElementById('loginBox');
+  const authMount = document.getElementById('authMount');
+  const pass = document.getElementById('passBox');
+  const storePath = document.getElementById('storeBox');
   // verify input not empty. TODO: verify correct URL format.
   if (
     vaultServer.value.length > 0 &&
@@ -254,9 +254,9 @@ async function authButtonClick() {
 }
 
 async function tokenGrabberClick() {
-  var tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    var tab = tabs[tabIndex];
+    const tab = tabs[tabIndex];
     if (tab.url) {
       browser.tabs.sendMessage(tab.id, {
         message: 'fetch_token',

--- a/popup.html
+++ b/popup.html
@@ -45,6 +45,7 @@
     </main>
 
     <script src="Notify.js"></script>
+    <script src="common.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -2,15 +2,15 @@
 /* global browser Notify */
 
 const notify = new Notify(document.querySelector('#notify'));
-var resultList = document.getElementById('resultList');
-var searchInput = document.getElementById('vault-search');
+const resultList = document.getElementById('resultList');
+const searchInput = document.getElementById('vault-search');
 var currentUrl, currentTabId;
 var vaultServerAddress, vaultToken, storePath, secretList;
 
 async function mainLoaded() {
-  var tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    var tab = tabs[tabIndex];
+    const tab = tabs[tabIndex];
     if (tab.url) {
       currentTabId = tab.id;
       currentUrl = tab.url;
@@ -18,7 +18,7 @@ async function mainLoaded() {
     }
   }
 
-  if (searchInput.value.length != 0) {
+  if (searchInput.value.length !== 0) {
     currentUrl = searchInput.value;
   }
 
@@ -45,9 +45,12 @@ async function mainLoaded() {
 }
 
 async function querySecrets(searchString, manualSearch) {
+  if (searchString.length === 0) {
+    searchString = currentUrl;
+  }
+
   resultList.textContent = '';
-  var promises = [];
-  let anyMatch = false;
+  const promises = [];
   notify.clear();
 
   const storeComponents = storePathComponents(storePath);
@@ -56,15 +59,15 @@ async function querySecrets(searchString, manualSearch) {
   for (const secret of secretList) {
     promises.push(
       (async function () {
-        var secretsInPath = await fetch(
-          `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${secret}`,
-          {
-            method: 'LIST',
-            headers: {
-              'X-Vault-Token': vaultToken,
-              'Content-Type': 'application/json',
-            },
-          }
+        const secretsInPath = await fetch(
+            `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${secret}`,
+            {
+              method: 'LIST',
+              headers: {
+                'X-Vault-Token': vaultToken,
+                'Content-Type': 'application/json',
+              },
+            }
         );
         if (!secretsInPath.ok) {
           if (secretsInPath.status !== 404) {
@@ -75,14 +78,14 @@ async function querySecrets(searchString, manualSearch) {
           return;
         }
         for (const element of (await secretsInPath.json()).data.keys) {
-          var pattern = new RegExp(element);
-          var patternMatches = (pattern.test(searchString) || element.includes(searchString));
+          const pattern = new RegExp(element);
+          const patternMatches = (pattern.test(searchString) || element.includes(searchString));
           if (patternMatches) {
             const urlPath = `${vaultServerAddress}/v1/${storeComponents.root}/data/${storeComponents.subPath}/${secret}${element}`;
             const credentials = await getCredentials(urlPath);
             const credentialsSets = extractCredentialsSets(credentials.data.data);
 
-            for (let item of credentialsSets) {
+            for (const item of credentialsSets) {
               addCredentialsToList(item, element, resultList);
 
               matches++;
@@ -122,11 +125,11 @@ searchInput.addEventListener('keyup', searchHandler);
 
 function extractCredentialsSets(data) {
   const keys = Object.keys(data);
-  let credentials = [];
+  const credentials = [];
 
-  for (let key of keys) {
+  for (const key of keys) {
     if (key.startsWith('username')) {
-      let passwordField = 'password' + key.substring(8);
+      const passwordField = 'password' + key.substring(8);
       if (data[passwordField]) {
         credentials.push(
         { 
@@ -216,9 +219,9 @@ async function getCredentials(urlPath) {
 }
 
 async function fillCredentialsInBrowser(username, password) {
-  var tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    var tab = tabs[tabIndex];
+    const tab = tabs[tabIndex];
     if (tab.url) {
       // tabs.sendMessage(integer tabId, any message, optional object options, optional function responseCallback)
 
@@ -233,9 +236,9 @@ async function fillCredentialsInBrowser(username, password) {
 }
 
 async function copyStringToClipboard(string) {
-  var tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tabs = await browser.tabs.query({active: true, currentWindow: true});
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    var tab = tabs[tabIndex];
+    const tab = tabs[tabIndex];
     if (tab.url) {
       browser.tabs.sendMessage(tab.id, {
         message: 'copy_to_clipboard',

--- a/popup.js
+++ b/popup.js
@@ -8,7 +8,7 @@ var currentUrl, currentTabId;
 var vaultServerAddress, vaultToken, storePath, secretList;
 
 async function mainLoaded() {
-  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
     const tab = tabs[tabIndex];
     if (tab.url) {
@@ -34,14 +34,13 @@ async function mainLoaded() {
   vaultServerAddress = (await browser.storage.sync.get('vaultAddress'))
     .vaultAddress;
 
-  storePath = (await browser.storage.sync.get('storePath'))
-    .storePath;
+  storePath = (await browser.storage.sync.get('storePath')).storePath;
 
   secretList = (await browser.storage.sync.get('secrets')).secrets;
   if (!secretList) {
     secretList = [];
   }
-  querySecrets(currentUrl, (searchInput.value.length != 0));
+  querySecrets(currentUrl, searchInput.value.length != 0);
 }
 
 async function querySecrets(searchString, manualSearch) {
@@ -71,19 +70,25 @@ async function querySecrets(searchString, manualSearch) {
         );
         if (!secretsInPath.ok) {
           if (secretsInPath.status !== 404) {
-            notify.error(`Token is not able to read ${secret}... Try re-login`, {
-              removeOption: true,
-            });
+            notify.error(
+              `Token is not able to read ${secret}... Try re-login`,
+              {
+                removeOption: true,
+              }
+            );
           }
           return;
         }
         for (const element of (await secretsInPath.json()).data.keys) {
           const pattern = new RegExp(element);
-          const patternMatches = (pattern.test(searchString) || element.includes(searchString));
+          const patternMatches =
+            pattern.test(searchString) || element.includes(searchString);
           if (patternMatches) {
             const urlPath = `${vaultServerAddress}/v1/${storeComponents.root}/data/${storeComponents.subPath}/${secret}${element}`;
             const credentials = await getCredentials(urlPath);
-            const credentialsSets = extractCredentialsSets(credentials.data.data);
+            const credentialsSets = extractCredentialsSets(
+              credentials.data.data
+            );
 
             for (const item of credentialsSets) {
               addCredentialsToList(item, element, resultList);
@@ -137,11 +142,10 @@ function extractCredentialsSets(data) {
     if (key.startsWith('username')) {
       const passwordField = 'password' + key.substring(8);
       if (data[passwordField]) {
-        credentials.push(
-          {
-            username: data[key],
-            password: data['password' + key.substring(8)]
-          });
+        credentials.push({
+          username: data[key],
+          password: data['password' + key.substring(8)],
+        });
       }
     }
   }
@@ -225,7 +229,7 @@ async function getCredentials(urlPath) {
 }
 
 async function fillCredentialsInBrowser(username, password) {
-  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
     const tab = tabs[tabIndex];
     if (tab.url) {
@@ -235,7 +239,7 @@ async function fillCredentialsInBrowser(username, password) {
         message: 'fill_creds',
         username: username,
         password: password,
-        isUserTriggered: true
+        isUserTriggered: true,
       });
       break;
     }
@@ -243,7 +247,7 @@ async function fillCredentialsInBrowser(username, password) {
 }
 
 async function copyStringToClipboard(string) {
-  const tabs = await browser.tabs.query({active: true, currentWindow: true});
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
     const tab = tabs[tabIndex];
     if (tab.url) {


### PR DESCRIPTION
This is a relatively big PR with major enhancements.
I suggest reviewing one commit at a time starting from the oldest one first.

Enhancement 1:
Allow more than one password per website. VaultPass can now extract multiple username/password pairs from any given secret [possibly address issue #33]

Enhancement 2:
User can specify which KV store they wish to use (the default still being /secret/vaultPass) [possibly address issue #20]

Bug fixes:
  - Only display `No matching key found for this page` only once instead of once per selected directory
   
![image](https://user-images.githubusercontent.com/23632868/212316160-e1236979-aafe-4fd5-a511-abc52470ebc6.png)

  - Clearing the Search Secrets box will re-display credentials that match the current URL (if there were any)
  - Only autofill generic text field with matching username if it is part of the same form as the identified password field or when the user manually requested credentials to be filled