### PR TITLE
Improve token auto renewal process

### DIFF
--- a/background.js
+++ b/background.js
@@ -164,7 +164,7 @@ async function renewToken(force = false) {
         refreshTokenListener((token.data.ttl / 2));
       }
 
-      if (force || token.data.ttl <= 60) {
+      if (force || token.data.ttl <= 600) {
         console.log(`${new Date().toLocaleString()} Renewing Token...`);
         const newToken = await vault.post('/auth/token/renew-self', {
           increment: idealTokenTTL,

--- a/content.js
+++ b/content.js
@@ -10,7 +10,11 @@ browser.runtime.onMessage.addListener((request) => {
       handleCopyToClipboard(request);
       break;
     case 'fill_creds':
-      handleFillCredits(request);
+      if (!request.isUserTriggered) {
+        setTimeout(handleFillCredits.bind(null, request), 800);
+      } else {
+        handleFillCredits(request);
+      }
       break;
     case 'fetch_token':
       handleFetchToken();

--- a/manifest.json
+++ b/manifest.json
@@ -24,5 +24,5 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["activeTab", "storage", "clipboardWrite", "idle"]
+  "permissions": ["activeTab", "storage", "clipboardWrite", "idle", "alarms"]
 }

--- a/manifestV2.json
+++ b/manifestV2.json
@@ -28,6 +28,7 @@
     "storage",
     "clipboardWrite",
     "idle",
+    "alarms",
     "http://*/*",
     "https://*/*"
   ],

--- a/manifestV3.json
+++ b/manifestV3.json
@@ -24,5 +24,5 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["activeTab", "storage", "clipboardWrite", "idle"]
+  "permissions": ["activeTab", "storage", "clipboardWrite", "idle", "alarms"]
 }


### PR DESCRIPTION
Timers may not trigger when the background service worker become inactive.

Alarms are more appropriate for service workers.

In Firefox, we cannot detect when the device is being locked, so renew token on a regular basis so that at the end of a day, there's still enough life in the current token to survive the night.