### PR TITLE
Set KV store path when using "Get Token from Vault" button

### DIFF
--- a/options.js
+++ b/options.js
@@ -302,6 +302,11 @@ async function authButtonClick() {
 
 async function tokenGrabberClick() {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const storePath = document.getElementById('storeBox');
+  if (storePath.value.length > 0 && storePath.value[0] === '/') {
+    storePath.value = storePath.value.substring(1);
+  }
+  await browser.storage.sync.set({ storePath: storePath.value });
   for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
     const tab = tabs[tabIndex];
     if (tab.url) {


### PR DESCRIPTION
Currently, when clicking the "Get Token from Vault" button, `storePath` remains undefined. This causes the extension to not work with a custom secret path when authenticating with the token grabber method.

I have added a small change to the `tokenGrabberClick()` function that addresses this. Length and value check is the same as `authButtonClick()`.

This resolves issue #54 