### PR TITLE
Improve error handling in case Vault tab is not selected

### DIFF
--- a/options.js
+++ b/options.js
@@ -302,13 +302,17 @@ async function authButtonClick() {
 
 async function tokenGrabberClick() {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    const tab = tabs[tabIndex];
-    if (tab.url) {
-      browser.tabs.sendMessage(tab.id, {
-        message: 'fetch_token',
-      });
-      break;
+  const vaultServer = document.getElementById('serverBox');
+  const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true });
+
+  try {
+    await browser.tabs.sendMessage(currentTab.id, { message: 'fetch_token' });
+  } catch (err) {
+    if (!currentTab || !currentTab.url || !currentTab.url.startsWith(vaultServer.value)) {
+      notify.clear().error(`Please navigate to ${vaultServer.value} before grabbing the token.`);
+      return;
+    } else {
+      notify.clear().error(err.message);
     }
   }
 }


### PR DESCRIPTION
The current logic for finding the Vault tab does not work, because the extension has access only to the active tab. Also, when attempting to log in while having a different tab open, the extension silently fails. This PR solves both issues.

1. `tokenGrabberClick()` only checks the current tab. If the URL does not match the contents of the `Vault server URL` box, it will send an error message, instructing the user to navigate to Vault before attempting a login.
2. I also put `fetch_token` in a try block, now forwarding whatever error we are receiving in case it's not the above mentioned issue, so the user at least has some pointer to what is wrong.