### PR TITLE
Allow using multiple KV stores

### DIFF
--- a/options.html
+++ b/options.html
@@ -68,8 +68,19 @@
         </label>
 
         <label class="label">
-          KV Store:
-          <input type="text" class="input" name="store" id="storeBox" placeholder="Path to the KV store within Vault" value="secret/vaultPass"/>
+          KV Stores:
+          <div id="storePathsContainer" class="kv-list">
+            <input
+              type="text"
+              class="input store-path"
+              name="storePath"
+              placeholder="Path to the KV store within Vault"
+              value="secret/vaultPass"
+            />
+          </div>
+          <button id="addStorePathButton" class="button button--secondary button--small" type="button">
+            + Add KV Store
+          </button>
         </label>
 
         <input

--- a/popup.js
+++ b/popup.js
@@ -53,14 +53,23 @@ async function querySecrets(searchString, manualSearch) {
   const promises = [];
   notify.clear();
 
-  const storeComponents = storePathComponents(storePath);
   let matches = 0;
+  const delimiter = '##';
 
-  for (const secret of secretList) {
+  for (const combined of secretList) {
+    const parts = combined.split(delimiter);
+    if (parts.length !== 2) {
+      console.error('Invalid secret format: ', combined);
+      continue;
+    }
+    const secretStorePath = parts[0];
+    const secretName = parts[1];
+    const storeComponents = storePathComponents(secretStorePath);
+
     promises.push(
       (async function () {
         const secretsInPath = await fetch(
-          `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${secret}`,
+          `${vaultServerAddress}/v1/${storeComponents.root}/metadata/${storeComponents.subPath}/${secretName}`,
           {
             method: 'LIST',
             headers: {
@@ -71,7 +80,7 @@ async function querySecrets(searchString, manualSearch) {
         );
         if (!secretsInPath.ok) {
           if (secretsInPath.status !== 404) {
-            notify.error(`Unable to read ${secret}... Try re-login`, {
+            notify.error(`Unable to read ${secretName}... Try re-login`, {
               removeOption: true,
             });
           }
@@ -82,7 +91,7 @@ async function querySecrets(searchString, manualSearch) {
           const patternMatches =
             pattern.test(searchString) || element.includes(searchString);
           if (patternMatches) {
-            const urlPath = `${vaultServerAddress}/v1/${storeComponents.root}/data/${storeComponents.subPath}/${secret}${element}`;
+            const urlPath = `${vaultServerAddress}/v1/${storeComponents.root}/data/${storeComponents.subPath}/${secretName}/${element}`;
             const credentials = await getCredentials(urlPath);
             const credentialsSets = extractCredentialsSets(
               credentials.data.data
@@ -103,7 +112,6 @@ async function querySecrets(searchString, manualSearch) {
 
   try {
     await Promise.all(promises);
-
     if (matches > 0) {
       browser.browserAction.setBadgeText({
         text: `${matches}`,

--- a/style.css
+++ b/style.css
@@ -308,3 +308,36 @@ a {
 .gutter {
   margin-bottom: 1rem;
 }
+
+.kv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kv-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.kv-path {
+  flex: 1;
+}
+
+.kv-remove {
+  border: 1px solid var(--color-border);
+  background-color: var(--grey-subtle);
+  color: var(--grey);
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  border-radius: 2px;
+  transition: all 0.2s ease-in-out;
+}
+
+.kv-remove:hover {
+  background-color: var(--red);
+  color: white;
+  border-color: var(--red-alt);
+}


### PR DESCRIPTION
This PR adds support for multiple KV stores as backends in Vault, increasing flexibility for a wider range of secret-management workflows. This could be useful in a number of scenarios.

**Use cases:**

- **Independent team/department vaults**: different teams or departments can use wildly different paths in Vault.
- **Hybrid personal/team vaults**: run one backend for personal secrets and another for team-shared secrets, keeping policies and permissions neatly separated.

To implement this, each entry in `secretList` now has both the store path and the secret name in a single string, separated by the delimiter `##`. At login time, you can add as many KV stores as you like:

<img width="401" alt="Screenshot 2025-05-13 at 13 24 38" src="https://github.com/user-attachments/assets/39e58f61-a3a3-41a7-9017-5d0256221498" />

After authenticating, you can activate or deactivate individual secrets from any of your configured backends:

<img width="401" alt="Screenshot 2025-05-13 at 13 24 56" src="https://github.com/user-attachments/assets/f8000ddc-7189-4206-bb5a-5a1ab274233d" />