### PR TITLE
Fix: only show credentials choice popup on real login forms

### DIFF
--- a/content.js
+++ b/content.js
@@ -235,7 +235,11 @@ window.addEventListener('message', (event) => {
 
 chrome.runtime.onMessage.addListener((request) => {
   if (request.type === 'show_matches_popup_iframe') {
-    showMatchesPopupIframe(request.matches);
+    const hasUsername = !!findUsernameNodeIn(document, true);
+    const hasPassword = !!findPasswordInput();
+    if (hasUsername && hasPassword) {
+      showMatchesPopupIframe(request.matches);
+    }
   }
 });
 


### PR DESCRIPTION
This patch fixes an issue with my previously accepted PR, where `promptUserForChoice()` was firing on *every* page load matching the URL pattern—even after a successful login—resulting in unwanted popups.

Now, before displaying the credential-selection iframe, we verify that the page actually contains both a username and a password field by reusing our existing helpers (`findUsernameNodeIn()` and `findPasswordInput()`).

This ensures the credential chooser only appears where it belongs—on real login forms—and not on every subsequent navigation. Apologies for the oversight!