### PR TITLE
Feat: Add a password generator button in Add Key

### DIFF
--- a/addKey.html
+++ b/addKey.html
@@ -74,7 +74,10 @@
         </div>
 
         <div class="form-group">
-          <label for="password" class="label">Password:</label>
+          <div class="password-row">
+            <label for="password" class="label">Password:</label>
+            <button type="button" id="generatePasswordButton" class="button">Generate</button>
+          </div>
           <input
             type="password"
             id="password"

--- a/addKey.html
+++ b/addKey.html
@@ -76,7 +76,9 @@
         <div class="form-group">
           <div class="password-row">
             <label for="password" class="label">Password:</label>
-            <button type="button" id="generatePasswordButton" class="button">Generate</button>
+            <button type="button" id="generatePasswordButton" class="button">
+              Generate
+            </button>
           </div>
           <input
             type="password"

--- a/addKey.js
+++ b/addKey.js
@@ -3,7 +3,9 @@
 const notify = new Notify(document.querySelector('#notify'));
 const addKeyForm = document.getElementById('addKeyForm');
 const urlRegexInput = document.getElementById('urlRegex');
-const generatePasswordButton = document.getElementById('generatePasswordButton');
+const generatePasswordButton = document.getElementById(
+  'generatePasswordButton'
+);
 const cancelButton = document.getElementById('cancelButton');
 const secretPathSelect = document.getElementById('secretPath');
 

--- a/addKey.js
+++ b/addKey.js
@@ -1,8 +1,9 @@
-/* global Notify storePathComponents */
+/* global Notify storePathComponents,copyStringToClipboard */
 
 const notify = new Notify(document.querySelector('#notify'));
 const addKeyForm = document.getElementById('addKeyForm');
 const urlRegexInput = document.getElementById('urlRegex');
+const generatePasswordButton = document.getElementById('generatePasswordButton');
 const cancelButton = document.getElementById('cancelButton');
 const secretPathSelect = document.getElementById('secretPath');
 
@@ -15,6 +16,7 @@ async function mainLoaded() {
 
   // Set up event listeners
   addKeyForm.addEventListener('submit', handleFormSubmit);
+  generatePasswordButton.addEventListener('click', handleGeneratePassword);
   cancelButton.addEventListener('click', handleCancel);
 }
 
@@ -173,6 +175,23 @@ async function handleFormSubmit(event) {
   } catch (err) {
     notify.error(`Error saving key: ${err.message}`);
   }
+}
+
+function handleGeneratePassword() {
+  const length = 20;
+  const charset =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+~`|}{[]:;?><,./-=';
+  let password = '';
+
+  for (let i = 0; i < length; i++) {
+    const randomIndex = Math.floor(Math.random() * charset.length);
+    password += charset[randomIndex];
+  }
+  document.getElementById('password').value = password;
+
+  copyStringToClipboard(password);
+
+  notify.success('Generated password copied to clipboard!', { time: 5000 });
 }
 
 function handleCancel() {

--- a/common.js
+++ b/common.js
@@ -20,3 +20,17 @@ function storePathComponents(storePath) {
 if (!browser.browserAction) {
   browser.browserAction = chrome.browserAction ?? chrome.action;
 }
+
+async function copyStringToClipboard(string) {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
+    const tab = tabs[tabIndex];
+    if (tab.url) {
+      browser.tabs.sendMessage(tab.id, {
+        message: 'copy_to_clipboard',
+        string: string,
+      });
+      break;
+    }
+  }
+}

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-prototype-builtins */
-/* global Notify storePathComponents */
+/* global Notify storePathComponents,copyStringToClipboard */
 
 const notify = new Notify(document.querySelector('#notify'));
 const resultList = document.getElementById('resultList');
@@ -287,20 +287,6 @@ async function fillCredentialsInBrowser(username, password) {
         username: username,
         password: password,
         isUserTriggered: true,
-      });
-      break;
-    }
-  }
-}
-
-async function copyStringToClipboard(string) {
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  for (let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
-    const tab = tabs[tabIndex];
-    if (tab.url) {
-      browser.tabs.sendMessage(tab.id, {
-        message: 'copy_to_clipboard',
-        string: string,
       });
       break;
     }

--- a/style.css
+++ b/style.css
@@ -233,6 +233,11 @@ main {
 .form-group {
   margin-bottom: var(--space-lg);
 }
+.password-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
 .label {
   display: block;
   margin-bottom: var(--space-sm);


### PR DESCRIPTION
This PR add a button to generate a 20 char length password directly from the Add Key window.
The charset is Fort knox (`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+~`|}{[]:;?><,./-=`)

By clicking on Generate, the password input is being filled with the generated password and it is being copied to the clipboard.

I had to move the function copyStringToClipboard() from popup.js to common.js so the code can be reused in addKey.js.

<img width="426" height="614" alt="image" src="https://github.com/user-attachments/assets/5b3f1759-925b-4f90-a130-d8eef6128760" />

<img width="434" height="703" alt="image" src="https://github.com/user-attachments/assets/0bc5a2ce-a99b-4adc-ace6-39e6bd64c2f4" />

In the future it could be nice to add a way to customize the password generation in a tiny menu, like setting the desired password length, character range, etc.